### PR TITLE
Update administrate-field-image.gemspec for Rails 5

### DIFF
--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
-  gem.add_dependency "rails", "~> 4.2"
+  gem.add_dependency "rails", ">= 4.2"
 end


### PR DESCRIPTION
This is update is needed for administrate to support Rails 5.
