### PR TITLE
Lax version requirement on Rails

### DIFF
--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
-  gem.add_dependency "rails", "~> 4.2"
+  gem.add_dependency "rails", ">= 4.2"
 end

--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
-  gem.add_dependency "rails", ">= 4.2"
+  gem.add_dependency "rails", ">= 4.2", "< 5.1"
 end


### PR DESCRIPTION
This makes `administrate-field-image` compatible with Rails 5.
