### PR TITLE
Rails 5 compatibility

### DIFF
--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -1,10 +1,8 @@
 $:.push File.expand_path("../lib", __FILE__)
 
-require "administrate/field/image"
-
 Gem::Specification.new do |gem|
   gem.name = "administrate-field-image"
-  gem.version = Administrate::Field::Image::VERSION
+  gem.version = "0.0.2"
   gem.authors = ["Grayson Wright"]
   gem.email = ["wright.grayson@gmail.com"]
   gem.homepage = "https://github.com/graysonwright/administrate-field-image"

--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
   gem.add_dependency "rails", "~> 4.2"
-  
+
   gem.add_development_dependency "rspec", "~> 3.4"
 end

--- a/lib/administrate/field/image.rb
+++ b/lib/administrate/field/image.rb
@@ -4,8 +4,6 @@ require "rails"
 module Administrate
   module Field
     class Image < Administrate::Field::Base
-      VERSION = "0.0.2"
-
       class Engine < ::Rails::Engine
       end
     end


### PR DESCRIPTION
Since Rails 5 compatibility is coming in the upstream administrate, here's a quick PR to make this field still work in that version.

I've also moved the `VERSION` out of lib. The reason for this was a circular dependency issue when installing to a clean environment - loading the file containing `VERSION` required administrate to be installed, but it is not installed at the time Bundler needs to read the `VERSION` to calculate dependencies.
