### PR TITLE
Relax version requirements on administrate gem

### DIFF
--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
+  gem.add_dependency "administrate", ">= 0.2.0.rc1"
   gem.add_dependency "rails", ">= 4.2", "< 5.1"
 end


### PR DESCRIPTION
The administrate v0.3.0 has been released.
And it depends on this branch in its Gemfile.
We have to relax version requirements in order to develop administrate.