### PR TITLE
Loosen the dependencies on Rails and Administrate

### DIFF
--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
-  gem.add_dependency "rails", "~> 4.2"
+  gem.add_dependency "administrate", ">= 0.2.0.rc1"
+  gem.add_dependency "rails", ">= 4.2"
 
   gem.add_development_dependency "rspec", "~> 3.4"
 end


### PR DESCRIPTION
This allows for Rails 5 and newer versions of Administrate.

This incorporates #4, but expands for administrate itself.