### PR TITLE
Don't crash if image is nil/blank

### DIFF
--- a/app/views/fields/image/_show.html.erb
+++ b/app/views/fields/image/_show.html.erb
@@ -15,4 +15,4 @@ By default, the attribute is rendered as an image tag.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
 %>
 
-<%= image_tag field.data %>
+<%= image_tag field.data if field.data.present? %>


### PR DESCRIPTION
Currently the app crashes on the show page if any of your image fields are nil/blank. This PR fixes that by only showing the image if it's present.