### PR TITLE
remove explicit dependency on rails

### DIFF
--- a/administrate-field-image.gemspec
+++ b/administrate-field-image.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.add_dependency "administrate", ">= 0.2.0.rc1"
-  gem.add_dependency "rails", ">= 4.2"
 
   gem.add_development_dependency "rspec", "~> 3.4"
 end


### PR DESCRIPTION
Administrate already states it depends on Rails. If we need to manage the version of Rails, we would have to change it in two places.