### PR TITLE
Fix #index preview crash on when no image attached

### DIFF
--- a/app/views/fields/image/_index.html.erb
+++ b/app/views/fields/image/_index.html.erb
@@ -15,4 +15,4 @@ By default, the attribute is rendered as an image tag.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
 %>
 
-<%= image_tag field.data %>
+<%= image_tag field.data if field.data.present? %>


### PR DESCRIPTION
When obejcts have no activerecord blob attached to the field, `#index` didn't account for that, resulting in method call on `nil`.
The `#show` method already has a `#present?` check, so it was added it to `#index` as well, fixing this issue.

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/9074800/171377038-40560fd5-42e7-4c29-bc04-2a624001b79a.png">
